### PR TITLE
Update TOKEN_RE constant to better match against BBCode tags

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,7 @@ export const NEWLINE_RE = /\r?\n/g;
 export const LINE_BREAK = '<br />';
 
 export const SPACE_RE = /^\s*$/;
-export const TOKEN_RE = /(\[\/?.+?\])/;
+export const TOKEN_RE = /(\[(?:(?:\/[^\]\[\n]+)|(?:[^\[\]\/\n]+?))\])/;
 export const START_NEWLINE_RE = /^\r?\n/;
 
 export const ESCAPE_RE = /[&<>"]/g;


### PR DESCRIPTION
Revision to the BBCode tag regex to better handle leading or trailing square brackets that do not open or close a tag.

Example: Previously, the BBCode `[b]This is bold text![[/b]` would incorrectly be split into array elements `["[b]", "This is bold text!", "[[/b]"]` and the tag would not be closed.

With the updated regex, the line will now correctly be split into array elements `["[b]", "This is bold text![", "[/b]"]` and properly resolve.